### PR TITLE
fix: prevent Cobe globe from staying invisible when texture load fails

### DIFF
--- a/components/CobeGlobe.vue
+++ b/components/CobeGlobe.vue
@@ -41,6 +41,7 @@ let thetaAtDown = 0
 let currentSize = 0
 let isHovering = false
 let labelTimeout: ReturnType<typeof setTimeout> | null = null
+let readyFallbackTimeout: ReturnType<typeof setTimeout> | null = null
 
 // Locations with display labels  (as const → tuple types required by Cobe)
 const HCM_LAT = 10.82
@@ -202,8 +203,17 @@ onMounted(async () => {
       // Fade in once texture is bound and landmasses are visible
       globeReady.value = true
     }
+    img.onerror = () => {
+      // Avoid keeping canvas invisible if texture file fails to load
+      globeReady.value = true
+    }
     img.src = '/world-map.png'
   })
+
+  // Fallback: always show globe even if external texture handshake fails
+  readyFallbackTimeout = setTimeout(() => {
+    globeReady.value = true
+  }, 1200)
 })
 
 onBeforeUnmount(() => {
@@ -220,6 +230,7 @@ onBeforeUnmount(() => {
     container.removeEventListener('pointerleave', onPointerLeave)
   }
   if (labelTimeout) clearTimeout(labelTimeout)
+  if (readyFallbackTimeout) clearTimeout(readyFallbackTimeout)
 })
 </script>
 


### PR DESCRIPTION
### Motivation
- The globe canvas is hidden by default (`opacity: 0`) and is only shown when `globeReady` becomes true, so a failed or stalled texture load can leave the globe permanently invisible. 
- The external texture handshake used to replace Cobe's embedded base64 can fail in some environments (AMD/ANGLE on Windows), so a robust fallback is required. 

### Description
- Add `img.onerror` handling when loading `/world-map.png` to set `globeReady = true` so the canvas is not permanently hidden. 
- Add a `readyFallbackTimeout` (1200ms) that forces `globeReady = true` if the texture handshake does not complete. 
- Declare `readyFallbackTimeout` and clear it in `onBeforeUnmount` to avoid leaking timers. 
- Changes are made in `components/CobeGlobe.vue`. 

### Testing
- Ran `npm run build` and the production build completed successfully (client and server built, prerender completed). 
- Verified the modified file committed and repository status via `git status` and `git commit` (commit included the fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fbca2ae483269893ed93c4cb02d0)