### PR TITLE
fix(globe): drop opaque context so the orb reads on a light page

### DIFF
--- a/components/CobeGlobe.vue
+++ b/components/CobeGlobe.vue
@@ -141,10 +141,11 @@ onMounted(async () => {
     height: size * 2,
     phi,
     theta,
-    // alpha:false makes the canvas opaque. The globe's interior fragments output
-    // alpha 0, so with the default alpha:true the sphere composites transparently
-    // onto the page and the land dots disappear.
-    context: { alpha: false, powerPreference: 'high-performance' } as WebGLContextAttributes,
+    // Keep Cobe's default alpha:true so the canvas stays transparent outside the
+    // sphere — the globe reads as a clean round orb on the page instead of an
+    // opaque square. The sphere body itself renders opaque (opacity defaults to 1),
+    // so land dots stay crisp even over a light background.
+    context: { powerPreference: 'high-performance' } as WebGLContextAttributes,
 
     dark: 1,
     diffuse: 1.2,
@@ -207,6 +208,9 @@ onBeforeUnmount(() => {
   cursor: grab;
   touch-action: none;
   user-select: none;
+  /* Parent hero wrapper sets pointer-events:none; re-enable here so dragging
+     the globe works without the wrapper swallowing clicks elsewhere. */
+  pointer-events: auto;
 }
 
 .cobe-container:active {

--- a/components/SectionHero.vue
+++ b/components/SectionHero.vue
@@ -87,7 +87,7 @@
     </div>
 
     <div
-      class="pointer-events-none absolute top-0 right-0 hidden h-full w-1/2 items-center justify-center overflow-hidden opacity-70 md:flex"
+      class="pointer-events-none absolute top-0 right-0 hidden h-full w-1/2 items-center justify-center overflow-hidden md:flex"
     >
       <ClientOnly>
         <CobeGlobe />


### PR DESCRIPTION
With alpha:false the canvas cleared to opaque black, turning the area outside the sphere into a black square that the hero's opacity wrapper dimmed to a flat gray — the "gray blob" instead of a floating globe. Cobe's sphere body already renders opaque (opacity defaults to 1), so the land dots stay crisp without it.

Use Cobe's default alpha:true for a transparent canvas, remove the hero's opacity-70 wash so the globe shows at full strength, and re-enable pointer events on the globe itself so dragging works under the wrapper's pointer-events:none.